### PR TITLE
WIP: refactor real iter info

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,3 @@
 xtgeo>=2.14
 PyYAML
+pyarrow

--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -607,7 +607,7 @@ class _ExportItem:  # pylint disable=too-few-public-methods
 
         # define spec record
         meta["spec"] = OrderedDict()
-        meta["spec"]["columns"] = list(table.columns)
+        meta["spec"]["columns"] = list(table.column_names)
         meta["spec"]["size"] = table.num_columns * table.num_rows
 
         meta["bbox"] = None

--- a/src/fmu/dataio/_export_item.py
+++ b/src/fmu/dataio/_export_item.py
@@ -79,7 +79,7 @@ class _ExportItem:  # pylint disable=too-few-public-methods
         self.index_df = index
         self.subtype = None
         self.classname = "unset"
-        self.name = "unknown"
+        self.name = None
         self.parent_name = None
 
         if self.verbosity is None:

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -336,7 +336,6 @@ def get_runinfo_from_pwd(pwd):
 
     logger.info("Getting runcontext from cwd: %s", pwd)
 
-    parents = Path(pwd).resolve().parents
     logger.info("Evaluating: %s", str(pwd.parents[0].name))
 
     _is_fmurun = False

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -293,46 +293,47 @@ def check_if_number(value):
 
     return value
 
+
 def get_runinfo_from_pwd(pwd):
     """Get the context in which fmu-dataio is running
 
-    Known contexts for running fmu-dataio:
+     Known contexts for running fmu-dataio:
 
-        FORWARD_MODEL:
-            cwd is runpath - /scratch/user/case/realization-X[/iter-X]
-            Iteration may or may not be present.
-            For now, do not support missing iteration.
-            This context can be detected by looking for the realization-.
-            pattern in cwd and its relative location.
+         FORWARD_MODEL:
+             cwd is runpath - /scratch/user/case/realization-X[/iter-X]
+             Iteration may or may not be present.
+             For now, do not support missing iteration.
+             This context can be detected by looking for the realization-.
+             pattern in cwd and its relative location.
 
-        Inside RMS, ERT-run:
-            cwd is /scratch/user/case/realization-X/iter-X/rms/model
-            Iteration may or may not be present. Do not support missing iter.
-            This context can be detected by looking for the realization-.
-            pattern + rms/model in cwd. Return "rms_job"
+         Inside RMS, ERT-run:
+             cwd is /scratch/user/case/realization-X/iter-X/rms/model
+             Iteration may or may not be present. Do not support missing iter.
+             This context can be detected by looking for the realization-.
+             pattern + rms/model in cwd. Return "rms_job"
 
-        ERT WORKFLOW:
-            cwd is config-path. realization-. pattern not present.
-            Currently not detectable. Return None
+         ERT WORKFLOW:
+             cwd is config-path. realization-. pattern not present.
+             Currently not detectable. Return None
 
-        Inside RMS, template-run (running the RMS GUI):
-            cwd is inherited.
-            Currently not detectable. Return None
+         Inside RMS, template-run (running the RMS GUI):
+             cwd is inherited.
+             Currently not detectable. Return None
 
-    The purpose of this utility function is to derive context by looking at the cwd.
+     The purpose of this utility function is to derive context by looking at the cwd.
 
-    Return runcontext as a dictionary:
-   {"is_fmurun": <bool>, "fmu_runcontext": <str>}
+     Return runcontext as a dictionary:
+    {"is_fmurun": <bool>, "fmu_runcontext": <str>}
 
-    where the following known runcontexts are supported
+     where the following known runcontexts are supported
 
-    * forward_job
-    * rms_job
+     * forward_job
+     * rms_job
 
-    if no runcontext can be confirmed, return {is_fmurun: False} 
+     if no runcontext can be confirmed, return {is_fmurun: False}
 
     """
-    
+
     logger.info("Getting runcontext from cwd: %s", pwd)
 
     parents = Path(pwd).resolve().parents
@@ -355,4 +356,4 @@ def get_runinfo_from_pwd(pwd):
         if pwd.name == "model" and pwd.parents[0].name == "rms":
             _runcontext = "rms_job"
 
-    return {"is_fmurun": _is_fmurun, "fmu_runcontext": _runcontext} 
+    return {"is_fmurun": _is_fmurun, "fmu_runcontext": _runcontext}

--- a/src/fmu/dataio/_utils.py
+++ b/src/fmu/dataio/_utils.py
@@ -355,4 +355,14 @@ def get_runinfo_from_pwd(pwd):
         if pwd.name == "model" and pwd.parents[0].name == "rms":
             _runcontext = "rms_job"
 
+    # detect if we are in rms/bin, running as an ERT forward job
+    # (which seems to be the case when building docs)
+    # pwd will look like this: /scratch/user/case/realization-0/iter-0/rms/bin
+    # we will call this "rms_job" as well.
+    if re.match("^realization-.", str(pwd.parents[2].name)):
+        _is_fmurun = True
+
+        if pwd.name == "bin" and pwd.parents[0].name == "rms":
+            _runcontext = "rms_job"
+
     return {"is_fmurun": _is_fmurun, "fmu_runcontext": _runcontext}

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -179,6 +179,13 @@ class ExportData:
         # so storing this into self._runinfo
         self._runinfo = _utils.get_runinfo_from_pwd(self._pwd)
 
+        # ...then we need to modify the export_root according to the context
+        _context = self._runinfo["fmu_runcontext"]
+        if _context == "ert_forward_job":
+            self.export_root = "share/results"
+            logger.info("fmu_runcontext is %s", _context)
+            logger.info("dataio.export_root is set to %s", self.export_root)
+
         # derive some existing attributes from the runinfo for later use
         self._is_fmurun = self._runinfo["is_fmurun"]
 

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -377,7 +377,6 @@ class ExportData:
 
         logger.info("runinfo is %s", self._runinfo)
 
-        folders = self._pwd
         logger.info("Folder to evaluate: %s", self._pwd)
         ertjob = OrderedDict()
 
@@ -389,8 +388,6 @@ class ExportData:
         # current working directory path: realfolder, iterfolder, casefolder
         # and userfolder. They can be named anything, except for the realization
         # folder which, by our assumptions, is _always_ named "realization-<n>".
-
-        realfolder_locs = {"rms_job": 2, "ert_forward_job": 1}
 
         fmu_runcontext = self._runinfo["fmu_runcontext"]
 

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -379,7 +379,6 @@ class ExportData:
 
         folders = self._pwd
         logger.info("Folder to evaluate: %s", self._pwd)
-        therealization = None
         ertjob = OrderedDict()
 
         iterfolder = None
@@ -422,8 +421,7 @@ class ExportData:
 
         self._iterfolder = iterfolder.name
         self._realfolder = realfolder.name
-
-        therealization = realfolder.name.replace("realization-", "")
+        self._realization_id = realfolder.name.replace("realization-", "")
 
         # store parameters.txt and jobs.json
         parameters_file = iterfolder / "parameters.txt"
@@ -469,7 +467,7 @@ class ExportData:
         # ------------------------------------------------------------------------------
         # get the realization metadata
         r_meta = OrderedDict()
-        r_meta["id"] = int(therealization)
+        r_meta["id"] = int(self._realization_id)
         r_meta["name"] = realfolder.name
         r_meta["uuid"] = _utils.uuid_from_string(
             c_meta["uuid"] + str(i_meta["id"]) + str(r_meta["id"])

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -271,7 +271,7 @@ class ExportData:
             logger.info(
                 "Based on the context, this is not an FMU run."
                 "Metadata for case, iteration and realization will not be populated"
-                )
+            )
             self._meta_fmu["case"] = None
             self._meta_fmu["iteration"] = None
             self._meta_fmu["realization"] = None
@@ -365,7 +365,7 @@ class ExportData:
         higher up and generated in-advance.
         """
 
-        logger.setLevel("DEBUG")
+        # logger.setLevel("DEBUG")
 
         logger.info("Process metadata for realization and iteration")
 
@@ -392,10 +392,10 @@ class ExportData:
 
         realfolder_locs = {"rms_job": 2, "ert_forward_job": 1}
 
-        fmu_runcontext = self._runinfo["fmu_runcontext"]   
+        fmu_runcontext = self._runinfo["fmu_runcontext"]
 
         if fmu_runcontext == "rms_job":
-            iterfolder = pathlib.Path(self._pwd).resolve().parents[1] 
+            iterfolder = pathlib.Path(self._pwd).resolve().parents[1]
             realfolder = pathlib.Path(self._pwd).resolve().parents[2]
             casefolder = pathlib.Path(self._pwd).resolve().parents[3]
             userfolder = pathlib.Path(self._pwd).resolve().parents[4]
@@ -428,6 +428,11 @@ class ExportData:
         if parameters_file.is_file():
             params = _utils.read_parameters_txt(parameters_file)
             ertjob["params"] = params
+        else:
+            logger.error(
+                "Could not find parameters.txt " "Looked here: %s", parameters_file
+            )
+            raise FileExistsError("parameters.txt was not found")
 
         jobs_file = iterfolder / "jobs.json"
         if jobs_file.is_file():

--- a/src/fmu/dataio/dataio.py
+++ b/src/fmu/dataio/dataio.py
@@ -403,7 +403,7 @@ class ExportData:
             userfolder = pathlib.Path(self._pwd).resolve().parents[2]
         else:
             logger.error("self._runinfo was %s", self._runinfo)
-            raise RuntimeError("fmu_runcontext was not a known context")
+            raise RuntimeError("Unknown context: %s", self._runinfo["fmu_runcontext"])
 
         # sanity check the realization folder, so we know we are not lost
         if not re.match("^realization-.", realfolder.name):

--- a/tests/test_fmu_dataio_generic.py
+++ b/tests/test_fmu_dataio_generic.py
@@ -81,26 +81,38 @@ def test_process_fmu_model():
     assert fmumodel["revision"] == "0.99.0"
 
 
-def test_process_fmu_realisation():
+def test_process_fmu_realization_iteration():
     """The (second order) private routine that provides realization and iteration."""
 
-    # test case 1, look like an FMU run
-    case = fmu.dataio.ExportData(runfolder=pathlib.Path(RUN))
+    base_runfolder = pathlib.Path("tests/data/drogon/ertrun1/")
+
+    # test case 1, look like an ert forward job
+    runfolder = base_runfolder / "realization-0" / "iter-0"
+    case = fmu.dataio.ExportData(runfolder=pathlib.Path(runfolder))
     case._config = CFG
     c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()
 
     logger.info("========== CASE")
-    logger.info("%s", json.dumps(c_meta, indent=2, default=str))
+    #logger.info("%s", json.dumps(c_meta, indent=2, default=str))
     logger.info("========== ITER")
-    logger.info("%s", json.dumps(i_meta, indent=2, default=str))
+    #logger.info("%s", json.dumps(i_meta, indent=2, default=str))
     logger.info("========== REAL")
-    logger.info("%s", json.dumps(r_meta, indent=2, default=str))
+    #logger.info("%s", json.dumps(r_meta, indent=2, default=str))
 
     assert r_meta["parameters"]["KVKH_CREVASSE"] == 0.3
     assert r_meta["parameters"]["GLOBVAR"]["VOLON_FLOODPLAIN_VOLFRAC"] == 0.256355
     assert c_meta["uuid"] == "a40b05e8-e47f-47b1-8fee-f52a5116bd37"
 
-    # test case 2, do not look like an FMU run
+    # test case 2, look like an RMS job during FMU run
+    runfolder = base_runfolder / "realization-0" / "iter-0" / "rms" / "model"
+    case = fmu.dataio.ExportData(runfolder=runfolder)
+    case._config = CFG
+    c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()
+    assert r_meta["parameters"]["KVKH_CREVASSE"] == 0.3
+    assert r_meta["parameters"]["GLOBVAR"]["VOLON_FLOODPLAIN_VOLFRAC"] == 0.256355
+    assert c_meta["uuid"] == "a40b05e8-e47f-47b1-8fee-f52a5116bd37"
+
+    # test case 3, look like something else
     case = fmu.dataio.ExportData(runfolder=pathlib.Path(RUN) / "some" / "path")
     case._config = CFG
     c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()

--- a/tests/test_fmu_dataio_generic.py
+++ b/tests/test_fmu_dataio_generic.py
@@ -93,11 +93,11 @@ def test_process_fmu_realization_iteration():
     c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()
 
     logger.info("========== CASE")
-    #logger.info("%s", json.dumps(c_meta, indent=2, default=str))
+    # logger.info("%s", json.dumps(c_meta, indent=2, default=str))
     logger.info("========== ITER")
-    #logger.info("%s", json.dumps(i_meta, indent=2, default=str))
+    # logger.info("%s", json.dumps(i_meta, indent=2, default=str))
     logger.info("========== REAL")
-    #logger.info("%s", json.dumps(r_meta, indent=2, default=str))
+    # logger.info("%s", json.dumps(r_meta, indent=2, default=str))
 
     assert r_meta["parameters"]["KVKH_CREVASSE"] == 0.3
     assert r_meta["parameters"]["GLOBVAR"]["VOLON_FLOODPLAIN_VOLFRAC"] == 0.256355
@@ -120,6 +120,7 @@ def test_process_fmu_realization_iteration():
     assert r_meta is None
     assert i_meta is None
     assert c_meta is None
+
 
 def test_raise_userwarning_missing_content(tmp_path):
     """Example on generating a GridProperty without content spesified."""

--- a/tests/test_fmu_dataio_generic.py
+++ b/tests/test_fmu_dataio_generic.py
@@ -26,7 +26,7 @@ CFG["stratigraphy"] = {"TopVolantis": {}}
 CFG["access"] = {"someaccess": "jail"}
 CFG["model"] = {"revision": "0.99.0"}
 
-RUN = "tests/data/drogon/ertrun1/realization-0/iter-0/rms"
+RUN = "tests/data/drogon/ertrun1/realization-0/iter-0/rms/model"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -83,11 +83,12 @@ def test_process_fmu_model():
 
 def test_process_fmu_realisation():
     """The (second order) private routine that provides realization and iteration."""
-    case = fmu.dataio.ExportData()
-    case._config = CFG
-    case._pwd = pathlib.Path(RUN)
 
+    # test case 1, look like an FMU run
+    case = fmu.dataio.ExportData(runfolder=pathlib.Path(RUN))
+    case._config = CFG
     c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()
+
     logger.info("========== CASE")
     logger.info("%s", json.dumps(c_meta, indent=2, default=str))
     logger.info("========== ITER")
@@ -99,6 +100,14 @@ def test_process_fmu_realisation():
     assert r_meta["parameters"]["GLOBVAR"]["VOLON_FLOODPLAIN_VOLFRAC"] == 0.256355
     assert c_meta["uuid"] == "a40b05e8-e47f-47b1-8fee-f52a5116bd37"
 
+    # test case 2, do not look like an FMU run
+    case = fmu.dataio.ExportData(runfolder=pathlib.Path(RUN) / "some" / "path")
+    case._config = CFG
+    c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()
+
+    assert r_meta is None
+    assert i_meta is None
+    assert c_meta is None
 
 def test_raise_userwarning_missing_content(tmp_path):
     """Example on generating a GridProperty without content spesified."""

--- a/tests/test_fmu_dataio_generic.py
+++ b/tests/test_fmu_dataio_generic.py
@@ -4,7 +4,6 @@ import shutil
 import re
 from collections import OrderedDict
 import logging
-import json
 import yaml
 import pytest
 import xtgeo

--- a/tests/test_fmu_dataio_generic.py
+++ b/tests/test_fmu_dataio_generic.py
@@ -5,6 +5,7 @@ import re
 from collections import OrderedDict
 import logging
 import yaml
+import json
 import pytest
 import xtgeo
 import fmu.dataio
@@ -92,11 +93,11 @@ def test_process_fmu_realization_iteration():
     c_meta, i_meta, r_meta = case._process_meta_fmu_realization_iteration()
 
     logger.info("========== CASE")
-    # logger.info("%s", json.dumps(c_meta, indent=2, default=str))
+    logger.info("%s", json.dumps(c_meta, indent=2, default=str))
     logger.info("========== ITER")
-    # logger.info("%s", json.dumps(i_meta, indent=2, default=str))
+    logger.info("%s", json.dumps(i_meta, indent=2, default=str))
     logger.info("========== REAL")
-    # logger.info("%s", json.dumps(r_meta, indent=2, default=str))
+    logger.info("%s", json.dumps(r_meta, indent=2, default=str))
 
     assert r_meta["parameters"]["KVKH_CREVASSE"] == 0.3
     assert r_meta["parameters"]["GLOBVAR"]["VOLON_FLOODPLAIN_VOLFRAC"] == 0.256355

--- a/tests/test_fmu_dataio_table.py
+++ b/tests/test_fmu_dataio_table.py
@@ -82,6 +82,7 @@ def test_table_io_arrow(tmp_path):
         metadata = yaml.safe_load(stream)
         assert metadata["data"]["layout"] == "table"
         assert metadata["data"]["spec"]["size"] == 6
+        assert metadata["data"]["spec"]["columns"] == ["STOIIP", "PORO"]
 
 
 def test_tables_io_larger_case_ertrun(tmp_path):

--- a/tests/test_fmu_dataio_table.py
+++ b/tests/test_fmu_dataio_table.py
@@ -114,9 +114,16 @@ def test_tables_io_larger_case_ertrun(tmp_path):
     )
 
     # make a fake DataFrame
-    table = pd.DataFrame({"STOIIP": [123, 345, 654], "PORO": [0.2, 0.4, 0.3]})
+    df = pd.DataFrame({"STOIIP": [123, 345, 654], "PORO": [0.2, 0.4, 0.3]})
 
-    exp.to_file(table, verbosity="INFO")
+    exp.to_file(df, verbosity="INFO")
 
     metadataout = out / ".sometable--what_descr.csv.yml"
+    assert metadataout.is_file() is True
+
+    # then try pyarrow
+    table = pa.Table.from_pandas(df)
+    exp.to_file(table, verbosity="INFO")
+
+    metadataout = out / ".sometable--what_descr.arrow.yml"
     assert metadataout.is_file() is True

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -168,22 +168,22 @@ def test_get_runinfo_from_pwd(tmp_path):
     )
     current.mkdir(parents=True, exist_ok=True)
     res = _utils.get_runinfo_from_pwd(current)
-    assert res["is_fmurun"] == True
+    assert res["is_fmurun"] is True
     assert res["fmu_runcontext"] == "ert_forward_job"
 
     # test case 2, context is rms job run by ERT
     res = _utils.get_runinfo_from_pwd(current / "rms" / "model")
-    assert res["is_fmurun"] == True
+    assert res["is_fmurun"] is True
     assert res["fmu_runcontext"] == "rms_job"
 
     # test case 3, context is rms job not run by ERT
     current = tmp_path / "some" / "path" / "rms" / "model"
     res = _utils.get_runinfo_from_pwd(current)
-    assert res["is_fmurun"] == False
+    assert res["is_fmurun"] is False
     assert res["fmu_runcontext"] is None
 
     # test case 4, context is an ert workflow
     current = tmp_path / "some" / "path" / "ert" / "model"
     res = _utils.get_runinfo_from_pwd(current)
-    assert res["is_fmurun"] == False
+    assert res["is_fmurun"] is False
     assert res["fmu_runcontext"] is None

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -163,9 +163,7 @@ def test_get_runinfo_from_pwd(tmp_path):
     """
 
     # test case 1, context is forward job
-    current = (
-        tmp_path / "scratch" / "field" / "user" / "case" / "realization-10" / "iter-0"
-    )
+    current = tmp_path / "user" / "case" / "realization-10" / "iter-0"
     current.mkdir(parents=True, exist_ok=True)
     res = _utils.get_runinfo_from_pwd(current)
     assert res["is_fmurun"] is True
@@ -187,3 +185,9 @@ def test_get_runinfo_from_pwd(tmp_path):
     res = _utils.get_runinfo_from_pwd(current)
     assert res["is_fmurun"] is False
     assert res["fmu_runcontext"] is None
+
+    # test case 5, context is rms/bin during FMU runs
+    current = tmp_path / "user" / "case" / "realization-10" / "iter-0" / "rms" / "bin"
+    res = _utils.get_runinfo_from_pwd(current)
+    assert res["is_fmurun"] is True
+    assert res["fmu_runcontext"] == "rms_job"

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -149,7 +149,7 @@ def test_parse_parameters_txt_justified():
     assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100
     assert res["LOG10_MULTREGT"]["MULT_VALYSAR_THERYS"] == -3.2582
 
-def test_get_context_from_pwd(tmp_path):
+def test_get_runinfo_from_pwd(tmp_path):
     """Test that correct context is derived from the current working directory
 
     There are 4 known contexts, 2 are supported for now:
@@ -164,15 +164,23 @@ def test_get_context_from_pwd(tmp_path):
     # test case 1, context is forward job
     current = tmp_path / "scratch" / "field" / "user" / "case" / "realization-10" / "iter-0"
     current.mkdir(parents=True, exist_ok=True)
-    assert _utils.get_context_from_pwd(current) == "ert_forward_job"
+    res = _utils.get_runinfo_from_pwd(current)
+    assert res["is_fmurun"] == True
+    assert res["fmu_runcontext"]  == "ert_forward_job"
 
     # test case 2, context is rms job run by ERT
-    assert _utils.get_context_from_pwd(current / "rms" / "model") == "rms_job"
+    res = _utils.get_runinfo_from_pwd(current / "rms" / "model")
+    assert res["is_fmurun"] == True
+    assert res["fmu_runcontext"]  == "rms_job"
 
     # test case 3, context is rms job not run by ERT
     current = tmp_path / "some" / "path" / "rms" / "model"
-    assert _utils.get_context_from_pwd(current) is None
+    res = _utils.get_runinfo_from_pwd(current)
+    assert res["is_fmurun"] == False
+    assert res["fmu_runcontext"] is None
 
     # test case 4, context is an ert workflow
     current = tmp_path / "some" / "path" / "ert" / "model"
-    assert _utils.get_context_from_pwd(current) is None
+    res = _utils.get_runinfo_from_pwd(current)
+    assert res["is_fmurun"] == False
+    assert res["fmu_runcontext"] is None

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -149,6 +149,7 @@ def test_parse_parameters_txt_justified():
     assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100
     assert res["LOG10_MULTREGT"]["MULT_VALYSAR_THERYS"] == -3.2582
 
+
 def test_get_runinfo_from_pwd(tmp_path):
     """Test that correct context is derived from the current working directory
 
@@ -162,16 +163,18 @@ def test_get_runinfo_from_pwd(tmp_path):
     """
 
     # test case 1, context is forward job
-    current = tmp_path / "scratch" / "field" / "user" / "case" / "realization-10" / "iter-0"
+    current = (
+        tmp_path / "scratch" / "field" / "user" / "case" / "realization-10" / "iter-0"
+    )
     current.mkdir(parents=True, exist_ok=True)
     res = _utils.get_runinfo_from_pwd(current)
     assert res["is_fmurun"] == True
-    assert res["fmu_runcontext"]  == "ert_forward_job"
+    assert res["fmu_runcontext"] == "ert_forward_job"
 
     # test case 2, context is rms job run by ERT
     res = _utils.get_runinfo_from_pwd(current / "rms" / "model")
     assert res["is_fmurun"] == True
-    assert res["fmu_runcontext"]  == "rms_job"
+    assert res["fmu_runcontext"] == "rms_job"
 
     # test case 3, context is rms job not run by ERT
     current = tmp_path / "some" / "path" / "rms" / "model"

--- a/tests/test_fmu_dataio_utils.py
+++ b/tests/test_fmu_dataio_utils.py
@@ -148,3 +148,31 @@ def test_parse_parameters_txt_justified():
     assert res["SENSNAME"] == "rms_seed"
     assert res["GLOBVAR"]["VOLON_PERMH_CHANNEL"] == 1100
     assert res["LOG10_MULTREGT"]["MULT_VALYSAR_THERYS"] == -3.2582
+
+def test_get_context_from_pwd(tmp_path):
+    """Test that correct context is derived from the current working directory
+
+    There are 4 known contexts, 2 are supported for now:
+
+    1) ERT forward job -> return "ert_forward_job"
+    2) RMS job, ERT run -> return "rms_job"
+    3) ERT workflow job (not supported) -> return None
+    4) RMS job, outside RMS (not supported) -> return None
+
+    """
+
+    # test case 1, context is forward job
+    current = tmp_path / "scratch" / "field" / "user" / "case" / "realization-10" / "iter-0"
+    current.mkdir(parents=True, exist_ok=True)
+    assert _utils.get_context_from_pwd(current) == "ert_forward_job"
+
+    # test case 2, context is rms job run by ERT
+    assert _utils.get_context_from_pwd(current / "rms" / "model") == "rms_job"
+
+    # test case 3, context is rms job not run by ERT
+    current = tmp_path / "some" / "path" / "rms" / "model"
+    assert _utils.get_context_from_pwd(current) is None
+
+    # test case 4, context is an ert workflow
+    current = tmp_path / "some" / "path" / "ert" / "model"
+    assert _utils.get_context_from_pwd(current) is None


### PR DESCRIPTION
As pre-requisite for handling the arrow files, this is a quick-fix to make fmu-dataio run with ERT forward jobs.

Identified problem is that fmu-dataio assumes that current working directory is <something>/rms/model, where "something" is either iteration-directory during ERT runs, or template location during GUI-runs (non-FMU). In forward jobs, the current working directory is the root of the realization - which, confusingly enough, translates to the iteration folder. E.g. case/realization/iteration/.

This clearly needs more work, but duct-taping this for now to get the SMRY with Arrow tested.
